### PR TITLE
Fix invalid but understandable non-escaped newlines in strings, trim trailing backslash

### DIFF
--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -558,6 +558,13 @@ describe('parser TestSuit', function () {
       it('should parse non-escaped newline', function () {
         expect(parse(`"line1\nline2"`)).equals('line1\nline2')
       })
+      it('should parse non-escaped newline inside string value', function () {
+        expect(parse(`{"key":"line1\\nline2`)).deep.equals({ key: 'line1\nline2' })
+        expect(parse(`{"key":"line1\nline2`)).deep.equals({ key: 'line1\nline2' })
+        expect(parse(`{"key":"line1\n`)).deep.equals({ key: 'line1\n' })
+        expect(parse(`{\n\t"key":"line1\n`)).deep.equals({ key: 'line1\n' })
+        expect(parse(`{\n\t"key":"line1\nline2"\n}`)).deep.equals({ key: 'line1\nline2' })
+      })
     })
     context('string quote', () => {
       it('should parse string with double quote', function () {
@@ -595,6 +602,18 @@ describe('parser TestSuit', function () {
     })
     it('should parse null', function () {
       expect(parse(null)).to.be.null
+    })
+  })
+
+  context('incomplete escaped characters', function () {
+    it('should ignore an incomplete escaped character (such as control character \\n)', function () {
+      expect(parse(`"1. here comes the newline\n`)).equals('1. here comes the newline\n')
+      expect(parse(`"2. here comes the newline\\`)).equals('2. here comes the newline')
+      expect(parse(`"4. here comes the newline\\n\\`)).equals('4. here comes the newline\n')
+      expect(parse(`"3. here comes the newline\\\\`)).equals('3. here comes the newline\\')
+      expect(parse(`"5. here comes the newline\\\\\\`)).equals('5. here comes the newline\\')
+      expect(parse(`"6. here comes the newline\\\\\\\\`)).equals('6. here comes the newline\\\\')
+      expect(parse(`"7. here comes the newline\n\\\\`)).equals('7. here comes the newline\n\\')
     })
   })
 })

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -10,6 +10,10 @@ export function parse(s: string | undefined | null): any {
   if (s === '') {
     return ''
   }
+  // remove incomplete escaped characters at the end of the string
+  s = s.replace(/\\+$/, match =>
+    match.length % 2 === 0 ? match : match.slice(0, -1),
+  )
   try {
     return JSON.parse(s)
   } catch (e) {
@@ -155,7 +159,7 @@ function parseString(s: string): ParseResult<string> {
       return [JSON.parse(str), s]
     }
   }
-  return [JSON.parse(s + '"'), '']
+  return [JSON.parse(s.replace(/\n/g, '\\n') + '"'), '']
 }
 
 parsers["'"] = parseSingleQuoteString
@@ -173,7 +177,7 @@ function parseSingleQuoteString(s: string): ParseResult<string> {
       return [JSON.parse('"' + str.slice(1, -1) + '"'), s]
     }
   }
-  return [JSON.parse('"' + s.slice(1) + '"'), '']
+  return [JSON.parse('"' + s.slice(1).replace(/\n/g, '\\n') + '"'), '']
 }
 
 function parseStringWithoutQuote(


### PR DESCRIPTION
Please consider this PR to fix some persistent issues even after v1.1.0, usually when streaming from an LLM.

Related to #4.